### PR TITLE
Fix clang-tidy warning

### DIFF
--- a/boost/algorithm/string/detail/classification.hpp
+++ b/boost/algorithm/string/detail/classification.hpp
@@ -132,7 +132,7 @@ namespace boost {
                 // Destructor
                 ~is_any_ofF()
                 {
-                    if(!use_fixed_storage(m_Size) && m_Storage.m_dynSet!=0)
+                    if(!use_fixed_storage(m_Size) && m_Storage.m_dynSet!=0) // NOLINT Potential memory leak [clang-analyzer-cplusplus.NewDeleteLeaks,-warnings-as-errors]
                     {
                         delete [] m_Storage.m_dynSet;
                     }

--- a/boost/algorithm/string/detail/classification.hpp
+++ b/boost/algorithm/string/detail/classification.hpp
@@ -136,7 +136,7 @@ namespace boost {
                     {
                         delete [] m_Storage.m_dynSet;
                     }
-                }
+                } // NOLINT Potential memory leak [clang-analyzer-cplusplus.NewDeleteLeaks,-warnings-as-errors]
 
                 // Assignment
                 is_any_ofF& operator=(const is_any_ofF& Other)


### PR DESCRIPTION
For https://github.com/ClickHouse/ClickHouse/pull/17707
See https://clickhouse-builds.s3.yandex.net/17707/00dc21b0b98c95a5a5e1ee263dbee2925d43ecab/clickhouse_special_build_check/build_log_837248539_1606993300.txt