### PR TITLE
Disable msan for epoll events

### DIFF
--- a/boost/asio/detail/impl/epoll_reactor.ipp
+++ b/boost/asio/detail/impl/epoll_reactor.ipp
@@ -31,6 +31,12 @@
 
 #include <boost/asio/detail/push_options.hpp>
 
+#if defined(__has_feature)
+#if __has_feature(memory_sanitizer)
+#include <sanitizer/msan_interface.h>
+#endif
+#endif
+
 namespace boost {
 namespace asio {
 namespace detail {
@@ -468,6 +474,11 @@ void epoll_reactor::run(long usec, op_queue<operation>& ops)
 
   // Block on the epoll descriptor.
   epoll_event events[128];
+#if defined(__has_feature)
+#if __has_feature(memory_sanitizer)
+  __msan_unpoison(events, 128);
+#endif
+#endif
   int num_events = epoll_wait(epoll_fd_, events, 128, timeout);
 
 #if defined(BOOST_ASIO_ENABLE_HANDLER_TRACKING)


### PR DESCRIPTION
Same assertion as https://github.com/ClickHouse-Extras/libuv/compare/84438304f41d8ea6670ee5409f4d6c63ca784f28...bc14c44b6269c458f2cc7e09eb300f4b64899903#diff-cf4c0dad7cbbf7751061ba552c3c50ef46abdeaaca477a491845d7e254f57b92