### PR TITLE
Add missing include for std::mutex

### DIFF
--- a/boost/system/detail/std_interoperability.hpp
+++ b/boost/system/detail/std_interoperability.hpp
@@ -10,6 +10,7 @@
 #include <system_error>
 #include <map>
 #include <memory>
+#include <mutex>
 
 //
 


### PR DESCRIPTION
This is part of a larger set of changes to support building ClickHouse on [illumos](https://illumos.org).