### PR TITLE
Annotate small_vector for MSan (for use-after-destruction detection)

### DIFF
--- a/boost/container/small_vector.hpp
+++ b/boost/container/small_vector.hpp
@@ -396,7 +396,22 @@ class small_vector_base
       : base_type(initial_capacity_t(), this->internal_storage(), capacity, ::boost::forward<AllocFwd>(a))
    {}
 
-   //~small_vector_base(){}
+   //! In case of MSan use-after-destruction detection is enabled
+   //! (-fsanitize-memory-use-after-dtor and poison_in_dtor=1 option is set)
+   //! small_vector will trigger use-of-uninitialized-value for non-pod types.
+   //! Suppress this (just like llvm does [1])
+   //!
+   //!   [1]: https://lists.llvm.org/pipermail/llvm-commits/Week-of-Mon-20150831/297043.html
+   //!
+   //! NOTE: we cannot use __msan_unpoison() here
+   //! since it will be poisoned just after dtor will return.
+#if defined(__has_feature)
+#    if __has_feature(memory_sanitizer)
+   __attribute__((no_sanitize_memory)) ~small_vector_base() {}
+#    endif
+#else
+   //~small_vector_base() {}
+#endif
 
    private:
    //The only member


### PR DESCRIPTION
Simple reproducer [1]:

    #include <boost/container/small_vector.hpp>

    struct Foo
    {
        std::string i;
        bool operator<(const Foo &rhs) const { return i < rhs.i; }
    };

    int main()
    {
        boost::container::small_vector<Foo, 10> vector;
        vector.reserve(3);
        for (size_t i = 0; i < 3; ++i)
            vector.push_back(Foo{});
        return 0;
    }

And run it:

```
    $ clang++ -O2 -g3 -fsanitize-memory-track-origins -fsanitize=memory test-msan-3.cpp -o test-msan-3; MSAN_OPTIONS='abort_on_error=1 poison_in_dtor=1' ./test-msan-3
==30125==WARNING: MemorySanitizer: use-of-uninitialized-value
    0 0x5555555f606e in std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::_M_dispose() /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/10.2.0/../../../../include/c++/10.2.0/bits/basic_string.h:231:6
    1 0x5555555f606e in std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::~basic_string() /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/10.2.0/../../../../include/c++/10.2.0/bits/basic_string.h:658:9
    2 0x5555555f606e in Foo::~Foo() /tmp/test-msan-3.cpp:3:8
    3 0x5555555f606e in void boost::container::allocator_traits<boost::container::small_vector_allocator<Foo, boost::container::new_allocator<void>, void> >::priv_destroy<Foo>(boost::move_detail::integral_constant<bool, false>, boost::container::small_vector_allocator<Foo, boost::container::new_allocator<void>, void>&, Foo*) /usr/include/boost/container/allocator_traits.hpp:394:11
    4 0x5555555f606e in void boost::container::allocator_traits<boost::container::small_vector_allocator<Foo, boost::container::new_allocator<void>, void> >::destroy<Foo>(boost::container::small_vector_allocator<Foo, boost::container::new_allocator<void>, void>&, Foo*) /usr/include/boost/container/allocator_traits.hpp:322:7
    5 0x5555555f606e in boost::container::dtl::disable_if_trivially_destructible<Foo*, void>::type boost::container::destroy_alloc_n<boost::container::small_vector_allocator<Foo, boost::container::new_allocator<void>, void>, Foo*, unsigned long>(boost::container::small_vector_allocator<Foo, boost::container::new_allocator<void>, void>&, Foo*, unsigned long) /usr/include/boost/container/detail/copy_move_algo.hpp:987:7
    6 0x5555555f606e in boost::container::vector<Foo, boost::container::small_vector_allocator<Foo, boost::container::new_allocator<void>, void>, void>::~vector() /usr/include/boost/container/vector.hpp:1098:7
    7 0x5555555f5cf8 in boost::container::small_vector_base<Foo, void, void>::~small_vector_base() /usr/include/boost/container/small_vector.hpp:369:7
    8 0x5555555f5cf8 in main /tmp/test-msan-3.cpp:16:1
    9 0x7ffff7a8cb24 in __libc_start_main (/usr/lib/libc.so.6+0x27b24)
    10 0x5555555751dd in _start (/tmp/test-msan-3+0x211dd)

  Memory was marked as uninitialized
    0 0x5555555d110b in __sanitizer_dtor_callback (/tmp/test-msan-3+0x7d10b)
    1 0x5555555f5cdc in boost::container::small_vector_base<Foo, void, void>::~small_vector_base() /usr/include/boost/container/small_vector.hpp:369:7
    2 0x5555555f5cdc in main /tmp/test-msan-3.cpp:16:1

SUMMARY: MemorySanitizer: use-of-uninitialized-value /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/10.2.0/../../../../include/c++/10.2.0/bits/basic_string.h:231:6 in std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::_M_dispose()
Exiting
Aborted (core dumped)
```

  [1]: https://gist.github.com/azat/9a9560bfddef36f7701023cafb7a778e

Originally it was found in clickhouse hyperscan test
(01681_hyperscan_debug_assertion) [2].

  [2]: https://gist.github.com/azat/020938e221d519717338f099606c39fb

Check boost version 1.70 (ch) and 1.75 (system).
Clang version 11.1.

Refs: https://lists.llvm.org/pipermail/llvm-commits/Week-of-Mon-20150831/297043.html
Refs: https://github.com/google/sanitizers/issues/854